### PR TITLE
Roll the dice on pressing the return key.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 by [Douglas P. Fields, Jr.](mailto:symbolics@lisp.engineer)
 w/ [Jared Pellegrini](https://github.com/jaredpellegrini)
+and [Kris Zaragoza](https://github.com/kzaragoza)
 
 license [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
@@ -15,6 +16,7 @@ Targets the [M5 Cardputer](https://docs.m5stack.com/en/core/Cardputer).
 
 # CHANGELOG
 
+* v0.8: Roll when enter/return key pressed.
 * v0.7: Added CRITICAL FAIL message
 * v0.6: Added toggle for exploding dice (default=on)
 * v0.5: Allow subtracting a roll using the number key just

--- a/savageRoller.ino
+++ b/savageRoller.ino
@@ -21,6 +21,7 @@
  *    when updating the display
  *
  * CHANGELOG
+ * v0.8: Roll on pressing the return/enter key.
  * v0.7: Added CRITICAL FAIL message
  * v0.6: Added toggle for exploding dice (default=on)
  * v0.5: Allow subtracting a roll using the number key just
@@ -39,7 +40,7 @@
 #include <vector>
 
 const uint8_t MAJOR_VERSION = 0;
-const uint8_t MINOR_VERSION = 7;
+const uint8_t MINOR_VERSION = 8;
 
 enum class Page { Splash, Roller };
 Page currentPage = Page::Splash; // What UI page are we displaying?

--- a/savageRoller.ino
+++ b/savageRoller.ino
@@ -240,7 +240,7 @@ void handleKeys() {
       includeResult = 0;
       stateChange = 1;
     }
-    if (isNewlyPressed(' ')) {
+    if (isNewlyPressed(' ') || M5Cardputer.Keyboard.keysState().enter) {
       calcResult = 1;
     }
     if (isNewlyPressed('/') || isNewlyPressed('?')) {

--- a/savageRoller.ino
+++ b/savageRoller.ino
@@ -505,7 +505,7 @@ void splashHandleDisplay() {
   M5Cardputer.Display.setTextDatum(textdatum_t::top_center);
   M5Cardputer.Display.drawString("24680 adds a die, odd subs", displayWidth / 2, 3 * fontHeight);
   M5Cardputer.Display.drawString("[w]ild, [e]xplode, +/- mod", displayWidth / 2, 4 * fontHeight);
-  M5Cardputer.Display.drawString("space roll, esc reset, ? help", displayWidth / 2, 5 * fontHeight);
+  M5Cardputer.Display.drawString("sp/ret rolls, esc reset, ? help", displayWidth / 2, 5 * fontHeight);
 
   M5Cardputer.Display.setTextColor(YELLOW);
   M5Cardputer.Display.setTextDatum(textdatum_t::bottom_left);


### PR DESCRIPTION
When checking to see if we should trigger a roll, add an additional check for the .enter field from the M5Cardputer keybaord abstraction. The library sets this to true when the enter key was pressed.