### PR TITLE
Add battery status screen.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Targets the [M5 Cardputer](https://docs.m5stack.com/en/core/Cardputer).
 * Each die explodes - adds another roll if it rolls the highest number.
 
 # CHANGELOG
-
+* v0.9: Display battery charge level on pressing the b key from the roller screen.
 * v0.8: Roll when enter/return key pressed.
 * v0.7: Added CRITICAL FAIL message
 * v0.6: Added toggle for exploding dice (default=on)

--- a/savageRoller.ino
+++ b/savageRoller.ino
@@ -716,6 +716,11 @@ void batteryHandleKeys() {
       currentPage = Page::Roller;
       firstRun = 1;
     }
+    if (isNewlyPressed('/') || isNewlyPressed('?')) {
+      // Show the instructions again.
+      currentPage = Page::Splash;
+      firstRun = 1;
+    }
   }
 }
 

--- a/savageRoller.ino
+++ b/savageRoller.ino
@@ -702,7 +702,7 @@ void batteryHandleDisplay() {
   M5Cardputer.Display.fillRect(left + width, displayHeight/2 - 5, 5, 10);
 
   // Show the text and percentage at the bottom of the screen.
-  M5Cardputer.Display.setTextColor(WHITE);
+  M5Cardputer.Display.setTextColor(LIGHTGREY);
   M5Cardputer.Display.setTextDatum(textdatum_t::bottom_center);
   M5Cardputer.Display.drawString(level_label, displayWidth/2, displayHeight);
 }

--- a/savageRoller.ino
+++ b/savageRoller.ino
@@ -666,6 +666,9 @@ void splashHandleKeys() {
     } else if (isNewlyPressed('c')) {
       currentPage = Page::DeckofCards;
       displayDeck();
+    } else if (isNewlyPressed('b')) {
+      currentPage = Page::Battery;
+      firstRun = 1;
     }
   }
 }


### PR DESCRIPTION
- Refactor handleKeys to rollerHandleKeys to clarify usage now that we have multiple modal keyboard handlers.
- Add a new screen to display a battery graphic and text percentage on pressing the 'b' key from the roller page.